### PR TITLE
Raven: fixing problem with JSValue.FromObject using wrong version of …

### DIFF
--- a/Jint/Directory.Build.props
+++ b/Jint/Directory.Build.props
@@ -5,7 +5,7 @@
     <AssemblyTitle>Jint</AssemblyTitle>
     <Description>Javascript interpreter for .NET which provides full ECMA 5.1 compliance.</Description>
     <BuildNumber Condition="'$(BuildNumber)' == ''">0</BuildNumber>
-    <VersionPrefix>3.0.3-ravendb</VersionPrefix>
+    <VersionPrefix>3.0.8-ravendb</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageId>Jint</PackageId>
     <PackageTags>javascript, interpreter</PackageTags>

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -342,11 +342,11 @@ namespace Jint.Native
                 {
                     var array = (System.Array)v;
 
-                    var jsArray = engine.Array.Construct(Arguments.Empty);
+                    var jsArray = e.Array.Construct(Arguments.Empty);
                     foreach (var item in array)
                     {
-                        var jsItem = JsValue.FromObject(engine, item);
-                        engine.Array.PrototypeObject.Push(jsArray, Arguments.From(jsItem));
+                        var jsItem = JsValue.FromObject(e, item);
+                        e.Array.PrototypeObject.Push(jsArray, Arguments.From(jsItem));
                     }
 
                     return jsArray;


### PR DESCRIPTION
…Jint.Engine object due to incorrect usage of the value inside the conversion function.

Note that if in the future we will try to merge this change into sebastian's branch, this was already fixed there.